### PR TITLE
Add html-to-markdown-mcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This list showcases real-world applications that were built using this approach.
 ## CLI Tools
 
 - [claude-code-statusline](https://github.com/levz0r/claude-code-statusline) - A customizable statusline displaying real-time session info, token usage, and cost in Claude Code.
+- [html-to-markdown-mcp](https://github.com/levz0r/html-to-markdown-mcp) - An MCP server that converts HTML content to Markdown using Turndown.js.
 
 ## Libraries & Frameworks
 


### PR DESCRIPTION
## Summary
- Adds html-to-markdown-mcp to the CLI Tools section

## About the project
An MCP server that converts HTML content to Markdown using Turndown.js, enabling Claude and other AI tools to fetch web pages and transform them into clean markdown.

## AI tools used
Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)