### PR TITLE
Add Markdown Printer

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This list showcases real-world applications that were built using this approach.
 
 ## Browser Extensions
 
-*Your extension here! See [Contributing](#contributing).*
+- [Markdown Printer](https://github.com/levz0r/markdown-printer) - A browser extension that converts and saves web pages as formatted Markdown files.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Markdown Printer to the Browser Extensions section

## About the project
A browser extension that converts and saves web pages as formatted Markdown files, enabling users to easily preserve and organize online content for documentation and note-taking.

## AI tools used
Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)